### PR TITLE
Added ros_cfh_example as ROS MetaPackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo apt-get install protobuf libprotoc-dev libprotobuf-dev protobuf-c-compiler 
 ### Cloning the Git repository:
 
     cd ~/catkin_ws/src/
-    git clone https://github.com/F34140r/ros-cfh-example.git
+    git clone https://github.com/F34140r/ros-cfh-example.git ./ros_cfh_example
 
 ### Compiling the node:
 

--- a/ros_cfh_example/CMakeLists.txt
+++ b/ros_cfh_example/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(ros_cfh_example)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/ros_cfh_example/package.xml
+++ b/ros_cfh_example/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package>
+  <name>ros_cfh_example</name>
+  <version>0.0.1</version>
+  <description>ROS metapackages for industrial robots.</description>
+  <license>GPLv3</license>
+
+  <author email="tbd@foo.com">RoCKIn</author>
+  <maintainer email="tbd@foo.com">RoCKIn</maintainer>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
Modified README.md instructions to clone into ros_cfh_example, so that catkin
doesn't complain about naming convention.

now you can just clone, and run catkin make --pkg ros_cfh_example
